### PR TITLE
wait a bit before performing the first dashboard task

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApw35hEAJvKoU2HK873xBx4+fDsLyz8GQjfZQ2oG+0AHIq9ckgrN60grZtGYiN6KrWEd/MCOGYvoGBqN5CzrmSHdtYA3SDuWfQWmN8IOrXBUgyV1eBtDqKR/mDLsW7eV/Ebj8hO7MOGQvXtj13vw9s2gW67sLClSl6GzZmLn1ELOmC8WcMJkXv9IgAoHnuhvjC45c1k2naE8tXEY635XD0IvVEleWkBAKSWNiECwGQcIIDu88QRzBBmI1xms63Wuqv4MTU2kNJMhJe6qX5QbZQSxxCbcKXJU3hNDGcOFESM5zb7OaJMiQhqX6NDTILm/ZTVHOQTh5V5Arpq8F/oT5sQIDAQAB",
 	"name": "Bing Pong Helper",
-	"version": "1.3.14.4",
+	"version": "1.3.15.19",
 	"description": "Extends the abilities of Bing Pong",
 	"manifest_version": 2,
 	"page_action": {

--- a/scripts/bp-helper.js
+++ b/scripts/bp-helper.js
@@ -15,6 +15,7 @@ var MAXIMUM_DELAY_BEFORE_SCROLLING_UP = 7000;
 var DELAY_BEFORE_RETURNING_AFTER_SEARCHING = 8000;
 var DASHBOARD_TASK_CLICK_DELAY = 2000;
 var TASK_TO_DASHBOARD_DELAY = 6000;
+var FIRST_TASK_ATTEMPT_DELAY = 10000;
 
 var globalResponse, dashboardLoads, logoutLoads, dashboardWindow, dashboardTab, searchWindow, searchTab, loginWindow, loginTab, loginTimeout, dashboardFunctionLoads, bpWindow, captchaTab, minDelay, maxDelay, dashboardTimeout, searchTimeout;
 var username, password;
@@ -465,7 +466,7 @@ function performTasks(taskList) {
 			});
 		}
 		
-		processNextTask();
+		setTimeout(processNextTask, FIRST_TASK_ATTEMPT_DELAY);
 	});
 }
 		


### PR DESCRIPTION
This commit fixes the bug referenced here:

https://www.reddit.com/r/bingpong/comments/42zuab/bug_all_dashboard_tasks_not_completed/

Cause: Bing Pong Helper opens up the Bing Rewards dashboard to perform
the dashboard tasks as expected, but it immediately attempts to click on
the last dashboard task before the dashboard even loads, causing the
click to fail. This commit fixes this issue by waiting a certain amount
of time (10 seconds), after which the dashboard has likely loaded.